### PR TITLE
Replace assertContains() with assertStringContainsString()

### DIFF
--- a/tests/Feature/Auth/LoginTest.php
+++ b/tests/Feature/Auth/LoginTest.php
@@ -163,7 +163,7 @@ class LoginTest extends TestCase
 
         $response->assertRedirect($this->loginGetRoute());
         $response->assertSessionHasErrors('email');
-        $this->assertContains(
+        $this->assertStringContainsString(
             'Too many login attempts.',
             collect($response
                 ->baseResponse


### PR DESCRIPTION
Using assertContains() with string haystacks is deprecated and will not be supported in PHPUnit 9